### PR TITLE
Fix: Correct score display and adjust end-of-quiz messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,12 +63,12 @@
 
       <template x-if="screen === 'end'">
         <div class="text-center">
-          <h2 class="text-xl mb-6">Score final : <span x-text="score"></span> / 20</h2>
-          <p x-show="score < 5">😞 Oh non! Tu peux faire mieux. Tu as sûrement besoin de plus de connaissances.</p>
-          <p x-show="score >= 5 && score < 10">🙂 Pas mal, mais il y a encore des choses à apprendre. Continue à
+          <h2 class="text-xl mb-6">Score final : <span x-text="score"></span> / <span x-text="questions.length"></span></h2>
+          <p x-show="score < 9">😞 Oh non! Tu peux faire mieux. Tu as sûrement besoin de plus de connaissances.</p>
+          <p x-show="score >= 9 && score < 18">🙂 Pas mal, mais il y a encore des choses à apprendre. Continue à
             étudier!</p>
-          <p x-show="score >= 8 && score < 15">😀 Bravo! Bon score! Tu es sur la bonne voie.</p>
-          <p x-show="score >= 12 && launchConfetti()">🎉 Félicitations! Tu es un expert en informatique!</p>
+          <p x-show="score >= 18 && score < 25">😀 Bravo! Bon score! Tu es sur la bonne voie.</p>
+          <p x-show="score >= 25 && launchConfetti()">🎉 Félicitations! Tu es un expert en informatique!</p>
           <button @click="restartQuiz()" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mt-4 transition-colors duration-150 ease-in-out">Recommencer le quiz</button>
         </div>
       </template>


### PR DESCRIPTION
This commit addresses a bug where the final score display was hardcoded and did not reflect the actual total number of questions. It also refines the end-of-quiz messages and their triggering conditions.

Key changes:
- Score Display: The end screen now dynamically displays the score out of the actual total number of questions (e.g., "score / 30").
- End-of-Quiz Messages:
    - Adjusted score thresholds for all messages to be proportional to the current total of 30 questions.
    - Ensured message conditions are distinct and non-overlapping.
    - Confetti trigger is tied to the highest score tier (>= 84%).
- Unit Tests:
    - Updated tests in `tests.js` to verify the `launchConfetti()` function is called at the correct new score threshold, indirectly validating the message condition logic.

These changes ensure accurate score reporting and appropriate user feedback based on performance.